### PR TITLE
Proton for Steam on Linux

### DIFF
--- a/en/stick_to_windows_hardcore_gamer.md
+++ b/en/stick_to_windows_hardcore_gamer.md
@@ -22,3 +22,8 @@ Note the upcoming Steambox will be running a fork of Debian and
 CEO of Valve (Gabe Newell) has pledged to support Linux with all
 of the company's games (Team Fortress 2, DOTA 2, Half Life, etc.) and upcoming titles.
 
+Valve has recently released a custom version of Wine called Proton
+that allows you to play a large library of Windows games on Linux,
+however, not all games are compatible and only a small number of them
+are currently certified to work by Valve.
+


### PR DESCRIPTION
Updated the page for games on the "The few cases where you should stick to Windows (for now)" category which mentions a new feature for Steam on Linux called Proton.